### PR TITLE
Fix eye icon and keyboard icon not showing in lockscreen

### DIFF
--- a/focalgdm3
+++ b/focalgdm3
@@ -138,6 +138,7 @@ dest="/usr/local/share/gnome-shell/theme/focalgdm3"
 install -D /dev/null $dest/gdm3.css
 install -D /dev/null $dest/focalgdm3.gresource.xml
 install -d $dest/icons/scalable/actions
+install -d $dest/icons/scalable/status
 
 gresource extract $source $prefix/gdm3.css > $dest/original.css
 gresource extract $source $prefix/checkbox.svg > $dest/checkbox.svg
@@ -147,16 +148,16 @@ gresource extract $source $prefix/checkbox-off-focused.svg > $dest/checkbox-off-
 gresource extract $source $prefix/toggle-on.svg > $dest/toggle-on.svg
 gresource extract $source $prefix/toggle-off.svg > $dest/toggle-off.svg
 gresource extract $source $prefix/icons/scalable/actions/pointer-drag-symbolic.svg > $dest/icons/scalable/actions/pointer-drag-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/keyboard-enter-symbolic.svg > $dest/icons/scalable/actions/keyboard-enter-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/keyboard-hide-symbolic.svg > $dest/icons/scalable/actions/keyboard-hide-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/keyboard-enter-symbolic.svg > $dest/icons/scalable/status/keyboard-enter-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/keyboard-hide-symbolic.svg > $dest/icons/scalable/status/keyboard-hide-symbolic.svg
 gresource extract $source $prefix/icons/scalable/actions/pointer-secondary-click-symbolic.svg > $dest/icons/scalable/actions/pointer-secondary-click-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/keyboard-shift-filled-symbolic.svg > $dest/icons/scalable/actions/keyboard-shift-filled-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/keyboard-caps-lock-filled-symbolic.svg > $dest/icons/scalable/actions/keyboard-caps-lock-filled-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/keyboard-shift-filled-symbolic.svg > $dest/icons/scalable/status/keyboard-shift-filled-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/keyboard-caps-lock-filled-symbolic.svg > $dest/icons/scalable/status/keyboard-caps-lock-filled-symbolic.svg
 gresource extract $source $prefix/icons/scalable/actions/pointer-primary-click-symbolic.svg > $dest/icons/scalable/actions/pointer-primary-click-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/keyboard-layout-filled-symbolic.svg > $dest/icons/scalable/actions/keyboard-layout-filled-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/eye-not-looking-symbolic.svg > $dest/icons/scalable/actions/eye-not-looking-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/keyboard-layout-filled-symbolic.svg > $dest/icons/scalable/status/keyboard-layout-filled-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/eye-not-looking-symbolic.svg > $dest/icons/scalable/status/eye-not-looking-symbolic.svg
 gresource extract $source $prefix/icons/scalable/actions/pointer-double-click-symbolic.svg > $dest/icons/scalable/actions/pointer-double-click-symbolic.svg
-gresource extract $source $prefix/icons/scalable/actions/eye-open-negative-filled-symbolic.svg > $dest/icons/scalable/actions/eye-open-negative-filled-symbolic.svg
+gresource extract $source $prefix/icons/scalable/status/eye-open-negative-filled-symbolic.svg > $dest/icons/scalable/status/eye-open-negative-filled-symbolic.svg
 
 echo '@import url("resource:///org/gnome/shell/theme/original.css");
   #lockDialogGroup {
@@ -177,16 +178,16 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
     <file>checkbox-focused.svg</file>
     <file>checkbox.svg</file>
     <file>icons/scalable/actions/pointer-drag-symbolic.svg</file>
-    <file>icons/scalable/actions/keyboard-enter-symbolic.svg</file>
-    <file>icons/scalable/actions/keyboard-hide-symbolic.svg</file>
+    <file>icons/scalable/status/keyboard-enter-symbolic.svg</file>
+    <file>icons/scalable/status/keyboard-hide-symbolic.svg</file>
     <file>icons/scalable/actions/pointer-secondary-click-symbolic.svg</file>
-    <file>icons/scalable/actions/keyboard-shift-filled-symbolic.svg</file>
-    <file>icons/scalable/actions/keyboard-caps-lock-filled-symbolic.svg</file>
+    <file>icons/scalable/status/keyboard-shift-filled-symbolic.svg</file>
+    <file>icons/scalable/status/keyboard-caps-lock-filled-symbolic.svg</file>
     <file>icons/scalable/actions/pointer-primary-click-symbolic.svg</file>
-    <file>icons/scalable/actions/keyboard-layout-filled-symbolic.svg</file>
-    <file>icons/scalable/actions/eye-not-looking-symbolic.svg</file>
+    <file>icons/scalable/status/keyboard-layout-filled-symbolic.svg</file>
+    <file>icons/scalable/status/eye-not-looking-symbolic.svg</file>
     <file>icons/scalable/actions/pointer-double-click-symbolic.svg</file>
-    <file>icons/scalable/actions/eye-open-negative-filled-symbolic.svg</file>
+    <file>icons/scalable/status/eye-open-negative-filled-symbolic.svg</file>
   </gresource>
 </gresources>' > $dest/focalgdm3.gresource.xml
 


### PR DESCRIPTION
Fix svg files cannot be located from `gresource extract $source`. The following files
```
keyboard-enter-symbolic.svg
keyboard-hide-symbolic.svg
keyboard-shift-filled-symbolic.svg
keyboard-caps-lock-filled-symbolic.svg
keyboard-layout-filled-symbolic.svg
eye-not-looking-symbolic.svg
eye-open-negative-filled-symbolic.svg
```
are located in `$prefix/icons/scalable/status/` instead of `$prefix/icons/scalable/actions/`.